### PR TITLE
Add 40px anchor margin to make room for bootstrap header

### DIFF
--- a/website/build/index.html
+++ b/website/build/index.html
@@ -74,7 +74,7 @@
 
 <div class="row">
 	<div class="col-md-12">
-	  <a id="Overview"></a><h1>Overview</h1>
+	  <a id="Overview" class="anchor">&nbsp;</a><h1>Overview</h1>
 		<p >BayesDB, a Bayesian database table, lets users query the probable implications of their data as easily as a SQL database lets them query the data itself. Using the built-in Bayesian Query Language (BQL), users with no statistics training can solve basic data science problems, such as detecting predictive relationships between variables, inferring missing values, simulating probable observations, and identifying statistically similar database entries.</p>
 
 		<p >BayesDB is suitable for analyzing complex, heterogeneous data tables with up to tens of thousands of rows and hundreds of variables. No preprocessing or parameter adjustment is required, though experts can override BayesDB's default assumptions when appropriate.</p>
@@ -87,7 +87,7 @@
 
 <div class="row">
 	<div class="col-md-12">
-		<a id="Examples"></a><h1>Examples</h1>
+		<a id="Examples" class="anchor">&nbsp;</a><h1>Examples</h1>
 		<code>INFER salary FROM mytable WHERE age > 30;</code>
 		<p></p>
 		<p >Fill in missing data with the INFER command. Unlike a traditional regression model, where you need to separately train a supervised model for each column you're interested in predicting, INFER statements are flexible and work with any set of columns to predict.</p>
@@ -106,7 +106,7 @@
 
 <div class="row">
 	<div class="col-md-12">
-		<a id="Download"></a><h1>Download</h1>
+		<a id="Download" class="anchor">&nbsp;</a><h1>Download</h1>
 		<h3>Developer Alpha v0.1.0</h3>
 		<p>VM Quickstart: [<a href="downloads/bayesdb-v0.1-alpha-virtualbox_20131020.tgz">VirtualBox VM</a>] [<a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox Player</a>]</p>
 		<p>Documentation: [<a href="docs">User Documentation</a>] [<a href="https://github.com/mit-probabilistic-computing-project/vm-install-bayesdb/blob/master/VM_README.md">VM README</a>]</p>
@@ -119,7 +119,7 @@
 		
 <div class="row">
         <div class="col-md-12" style="margin-bottom: 140px;">
-		<a id="About"></a><h1>About</h1>
+		<a id="About" class="anchor">&nbsp;</a><h1>About</h1>
 		<p>BayesDB and its sister project, CrossCat, are being developed by Jay Baxter, Dan Lovell, and Vikash Mansinghka at Massuchusetts Institute of Technology and by Pat Shafto and Baxter Eaves at University of Louisville.</p>
 
 		<p>If you have any comments or questions, please feel free to email us at bayesdb [AT] mit.edu.</p>

--- a/website/build/stylesheets/all.css
+++ b/website/build/stylesheets/all.css
@@ -30,3 +30,5 @@ code {
 @media (max-width: 600px) {
   #logo-text{ font-size: 50px; }
 }
+
+a.anchor { position: relative; top: -40px; }

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -15,7 +15,7 @@ title: BayesDB
 
 <div class="row">
 	<div class="col-md-12">
-	  <a id="Overview"></a><h1>Overview</h1>
+	  <a id="Overview" class="anchor">&nbsp;</a><h1>Overview</h1>
 		<p >BayesDB, a Bayesian database table, lets users query the probable implications of their data as easily as a SQL database lets them query the data itself. Using the built-in Bayesian Query Language (BQL), users with no statistics training can solve basic data science problems, such as detecting predictive relationships between variables, inferring missing values, simulating probable observations, and identifying statistically similar database entries.</p>
 
 		<p >BayesDB is suitable for analyzing complex, heterogeneous data tables with up to tens of thousands of rows and hundreds of variables. No preprocessing or parameter adjustment is required, though experts can override BayesDB's default assumptions when appropriate.</p>
@@ -28,7 +28,7 @@ title: BayesDB
 
 <div class="row">
 	<div class="col-md-12">
-		<a id="Examples"></a><h1>Examples</h1>
+		<a id="Examples" class="anchor">&nbsp;</a><h1>Examples</h1>
 		<code>INFER salary FROM mytable WHERE age > 30;</code>
 		<p></p>
 		<p >Fill in missing data with the INFER command. Unlike a traditional regression model, where you need to separately train a supervised model for each column you're interested in predicting, INFER statements are flexible and work with any set of columns to predict.</p>
@@ -47,7 +47,7 @@ title: BayesDB
 
 <div class="row">
 	<div class="col-md-12">
-		<a id="Download"></a><h1>Download</h1>
+		<a id="Download" class="anchor">&nbsp;</a><h1>Download</h1>
 		<h3>Developer Alpha v0.1.0</h3>
 		<p>VM Quickstart: [<a href="downloads/bayesdb-v0.1-alpha-virtualbox_20131020.tgz">VirtualBox VM</a>] [<a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox Player</a>]</p>
 		<p>Documentation: [<a href="docs">User Documentation</a>] [<a href="https://github.com/mit-probabilistic-computing-project/vm-install-bayesdb/blob/master/VM_README.md">VM README</a>]</p>
@@ -60,7 +60,7 @@ title: BayesDB
 		
 <div class="row">
         <div class="col-md-12" style="margin-bottom: 140px;">
-		<a id="About"></a><h1>About</h1>
+		<a id="About" class="anchor">&nbsp;</a><h1>About</h1>
 		<p>BayesDB and its sister project, CrossCat, are being developed by Jay Baxter, Dan Lovell, and Vikash Mansinghka at Massuchusetts Institute of Technology and by Pat Shafto and Baxter Eaves at University of Louisville.</p>
 
 		<p>If you have any comments or questions, please feel free to email us at bayesdb [AT] mit.edu.</p>

--- a/website/source/stylesheets/all.css
+++ b/website/source/stylesheets/all.css
@@ -30,3 +30,5 @@ code {
 @media (max-width: 600px) {
   #logo-text{ font-size: 50px; }
 }
+
+a.anchor { position: relative; top: -40px; }


### PR DESCRIPTION
Currently on [the website](http://probcomp.csail.mit.edu/bayesdb/#Overview), if you click any of the nav links at the top you are brought down to the anchor, but because of the nav height, it obstructs part of the heading.

This change adds a 40px margin to make room for the headings. Solution from [StackOverflow](http://stackoverflow.com/questions/5070751/anchor-links-and-margins).
