### PR TITLE
Ruby 1.9.3 lock is not needed 

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '1.9.3'
-
 gem "middleman", "~> 3.0.6"
 gem "middleman-minify-html", "~> 3.0.0"
 gem "rack-contrib", "~> 1.1.0"


### PR DESCRIPTION
This allows users to bundle install with Ruby 2.0+
