### PR TITLE
Update persistence_layer.py

### DIFF
--- a/bayesdb/persistence_layer.py
+++ b/bayesdb/persistence_layer.py
@@ -22,7 +22,8 @@ import os
 import sys
 import datetime
 import json
-import pickle
+import cPickle as pickle
+#import pickle
 import shutil
 import contextlib
 import threading


### PR DESCRIPTION
cPickle is much faster than pickle. The query time is reduced by 50% on "create_btable"
